### PR TITLE
Extend the maximum length of hostname and path fields

### DIFF
--- a/DiscoverOctoPrintAction.qml
+++ b/DiscoverOctoPrintAction.qml
@@ -615,7 +615,7 @@ Cura.MachineAction
                 TextField
                 {
                     id: addressField
-                    maximumLength: 30
+                    maximumLength: 255
                     width: Math.floor(parent.width * 0.6)
                     validator: RegExpValidator
                     {
@@ -649,7 +649,7 @@ Cura.MachineAction
                 TextField
                 {
                     id: pathField
-                    maximumLength: 30
+                    maximumLength: 255
                     width: Math.floor(parent.width * 0.6)
                     validator: RegExpValidator
                     {


### PR DESCRIPTION
FQDNs can be up to 255 characters per RFC 1035 section 2.3.4. I felt the path variable should also be made longer.